### PR TITLE
Use prettyJSON from new heroku-cli-util

### DIFF
--- a/commands/api.js
+++ b/commands/api.js
@@ -3,17 +3,6 @@
 let cli = require('heroku-cli-util');
 let fs  = require("co-fs");
 
-function highlight(response) {
-  let json = JSON.stringify(response, null, '\t');
-  if (process.stdout.isTTY) {
-    let cardinal = require("cardinal");
-    let theme = require("cardinal/themes/tomorrow-night");
-    return cardinal.highlight(json, { json: true, theme: theme });
-  } else {
-    return json;
-  }
-}
-
 module.exports = {
   topic: 'api',
   description: 'make a single API request',
@@ -63,6 +52,10 @@ Examples:
       request.body = yield fs.readFile('/dev/stdin', 'utf8');
     }
     let response = yield heroku.request(request);
-    cli.log(highlight(response));
+
+    if (typeof response === "object")
+      cli.styledJSON(response);
+    else
+      cli.log(response);
   })
 };

--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
     "postversion": "npm publish && git push && git push --tags"
   },
   "dependencies": {
-    "cardinal": "0.6.0",
     "co": "^4.5.4",
     "co-fs": "^1.2.0",
-    "heroku-cli-util": "^5.2.1"
+    "heroku-cli-util": "5.8.4"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
Use prettyJSON from `heroku-cli-util` instead of bundling the same dependencies separately.