### PR TITLE
Fix JSON payload handling for requests with payload

### DIFF
--- a/commands/api.js
+++ b/commands/api.js
@@ -49,7 +49,14 @@ Examples:
     let version = context.flags.version || "3";
     request.headers = { 'Accept': `application/vnd.heroku+json; version=${version}` };
     if (request.method === "PATCH" || request.method === "PUT" || request.method === "POST") {
-      request.body = yield fs.readFile('/dev/stdin', 'utf8');
+      let body = yield fs.readFile('/dev/stdin', 'utf8')
+      let parsedBody
+      try {
+        parsedBody = JSON.parse(body)
+      } catch(e) {
+        throw new Error("Request body must be valid JSON")
+      }
+      request.body = parsedBody
     }
     let response = yield heroku.request(request);
 


### PR DESCRIPTION
The Heroku API client actually handles encoding of the body for us, so
when we were passing the unparsed input string directly, that was
being sent as a JSON *string* containing the full JSON payload. That
is, instead of sending the bytes

  `{ "foo": "bar" }`

we were sending the bytes

  `"{\"foo\": \"bar\" }"`

and while technically this is valid JSON, it is not what the user
intended nor what the endpoint expects.

Instead, we parse the input and pass the resulting object to the
request, letting the client handle re-encoding for us.