### PR TITLE
Read file synchronously

### DIFF
--- a/commands/api.js
+++ b/commands/api.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const fs = require('co-fs')
+const fs = require('fs')
 const {inspect} = require('util')
 
 module.exports = {
@@ -58,7 +58,7 @@ Examples:
       request.headers['Accept-Inclusion'] = context.flags['accept-inclusion']
     }
     if (request.method === 'PATCH' || request.method === 'PUT' || request.method === 'POST') {
-      let body = await fs.readFile('/dev/stdin', 'utf8')
+      let body = fs.readFileSync('/dev/stdin', 'utf8')
       let parsedBody
       try {
         parsedBody = JSON.parse(body)

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "url": "https://github.com/heroku/heroku-api-plugin/issues"
   },
   "dependencies": {
-    "co": "^4.5.4",
-    "co-fs": "^1.2.0",
     "heroku-cli-util": "^6.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,24 +169,7 @@ cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
 
-co-from-stream@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/co-from-stream/-/co-from-stream-0.0.0.tgz#1a5cd8ced77263946094fa39f2499a63297bcaf9"
-  dependencies:
-    co-read "0.0.1"
-
-co-fs@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/co-fs/-/co-fs-1.2.0.tgz#a6df045ce58c04eed45586ff4385032813aba64e"
-  dependencies:
-    co-from-stream "0.0.0"
-    thunkify "0.0.1"
-
-co-read@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/co-read/-/co-read-0.0.1.tgz#f81b3eb8a86675fec51e3d883a7f564e873c9389"
-
-co@4.6.0, co@^4.5.4, co@^4.6.0:
+co@4.6.0, co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
@@ -1507,10 +1490,6 @@ text-table@~0.2.0:
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-thunkify@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-0.0.1.tgz#bd5d36b1069b4078e5dcbac8fab45359bea6183d"
 
 timed-out@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
The plug-in is currently broken for `PATCH`, `PUT` and `POST` requests. It tries to parse `undefined` as JSON which obviously fails:

    % echo '{ "name": "foo" }' | heroku api POST /apps
     ▸    Request body must be valid JSON	

I changed to read the file synchronously. This had the added benefit of being able to remove two packages.

    % echo '{ "name": "foo" }' | heroku api POST /apps
     ▸    Name is already taken

The plug-in broke in 599b6e4bb2070ca9c93d8800c5fd10e3ba508f18. Should we improve the testing so it can't happen again?