### PR TITLE
Read from stdin rather than /dev/stdin

### DIFF
--- a/commands/api.js
+++ b/commands/api.js
@@ -1,8 +1,25 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const fs = require('fs')
 const {inspect} = require('util')
+
+function readStdin () {
+  return new Promise(function (resolve, reject) {
+    let buffer = ''
+    process.stdin.setEncoding('utf8')
+
+    process.stdin.on('readable', () => {
+      const chunk = process.stdin.read()
+      if (chunk !== null) {
+        buffer += chunk
+      }
+    })
+
+    process.stdin.on('end', () => {
+      resolve(buffer)
+    })
+  })
+}
 
 module.exports = {
   topic: 'api',
@@ -58,12 +75,12 @@ Examples:
       request.headers['Accept-Inclusion'] = context.flags['accept-inclusion']
     }
     if (request.method === 'PATCH' || request.method === 'PUT' || request.method === 'POST') {
-      let body = fs.readFileSync('/dev/stdin', 'utf8')
+      let body = await readStdin()
       let parsedBody
       try {
         parsedBody = JSON.parse(body)
       } catch (e) {
-        throw new Error('Request body must be valid JSON')
+        throw new Error('Request body must be valid JSON: ' + e.message)
       }
       request.body = parsedBody
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "chai": "^4.0.2",
     "mocha": "^3.4.2",
+    "mock-stdin": "0.3.1",
     "nock": "^9.0.13",
     "sinon": "^2.3.5",
     "sinon-chai": "^2.8.0",

--- a/test/init.js
+++ b/test/init.js
@@ -6,3 +6,6 @@ cli.raiseErrors = true
 let chai = require('chai')
 chai.use(require('sinon-chai'))
 chai.should()
+
+let nock = require('nock')
+nock.disableNetConnect()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,6 +1072,10 @@ mocha@^3.4.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
+mock-stdin@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-0.3.1.tgz#c657d9642d90786435c64ca5e99bbd4d09bd7dd3"
+
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"


### PR DESCRIPTION
@dickeyxxx tt and I ended up working on this simultaneously and I went a different direction reading from `process.stdin` instead.  I also fixed up the test suite and added a test for post, which I can make work by mocking out `fs`, just let me know what you want me to do with this.