### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## How to install this plugin
 
 ```shell
-$ heroku plugins:install api
+$ heroku plugins:install @heroku-cli/plugin-api
 ```
 
 ## Usage


### PR DESCRIPTION
The Heroku CLI no longer automatically expands plugin names like `api` to their long form package name (which in the case of this package, is `@heroku-cli/plugin-api`).

As such, the old install instructions in the README now result in a random package named [`api`](https://www.npmjs.com/package/api) being installed from npmjs.org, and that package is not a Heroku CLI plugin (!!).

Fixes #53.