### PR TITLE
Fixing CODEOWNERS format

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @heroku/frontend-dev-tooling
 #ECCN:Open Source
 #GUSINFO:Heroku Front End Dept (FE Infra & Arch),Heroku CLI
+* @heroku/frontend-dev-tooling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 #ECCN:Open Source
-#GUSINFO:Heroku Front End Dept (FE Infra & Arch),Heroku CLI
+#GUSINFO:Heroku Front End Dept (FE Infra & Arch),Heroku Front-End Arch
 * @heroku/frontend-dev-tooling


### PR DESCRIPTION
We're working to bring Heroku's Github Org up to Salesforce standards which involves fixing the CODEOWNERS files across our repos with the right information. 

This repo is showing up as having an invalid file because of the reference to an inactive GUS product Tag and wrong format - referenced in https://confluence.internal.salesforce.com/display/corescm/Create+a+GUS-Aware+CODEOWNERS+File:
"...ensure that the #GUSINFO: information is immediately above the first uncommented line.".