### PR TITLE
chore: add workflow-repo to ignore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,8 +4,10 @@ export default [
   ...oclif,
   {
     ignores: [
+      './dist',
       './lib',
       '**/*.js',
+      'workflows-repo/**/*',
     ],
   },
   {


### PR DESCRIPTION
Add workflows-repo/**/* to ESLint ignore patterns to prevent linting of external workflow definitions
